### PR TITLE
Get module list via api

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ Get the list of npm modules owned by a user.
 Although you can use [npm programmatically](https://www.npmjs.com/package/npm), you can't
 actually list the modules that a user owns.
 
-If there's a way to do it via an api, I couldn't find it. If you know of a way, please
-make a pull request with the changes. That'd be so awesome. Until then, this is really
-just a web page scraper.
-
 # using
 
 Install it the normal way:
@@ -19,10 +15,12 @@ Install it the normal way:
 
 You just call it with a string that's the user name:
 
-	var ownedModules = require('npm-owned-modules')
-	ownedModules('saibotsivad', function(err, modules) {
-		// modules array
-	})
+```javascript
+var ownedModules = require('npm-owned-modules')
+ownedModules('saibotsivad', function(err, modules) {
+	// modules array
+})
+```
 
 The modules list is just a simple array of module name strings, e.g.:
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://github.com/tobiaslabs/npm-owned-modules/issues"
   },
   "dependencies": {
-    "cheerio": "~0.18.0"
+    "JSONStream": "^0.10.0",
+    "concat-stream": "^1.4.7",
+    "request": "^2.53.0"
   },
   "devDependencies": {
     "tape": "~3.5.0"

--- a/test.js
+++ b/test.js
@@ -7,9 +7,9 @@ test('get the modules', function(t) {
 		t.ok(modules, 'modules should exist')
 		t.ok(Array.isArray(modules), 'modules should be an array')
 		t.ok(modules.length > 0, 'modules should contain at least one')
-		var allStrings = modules.filter(function(module) {
+		var allStrings = modules.every(function(module) {
 			return typeof module === 'string'
-		}).length === modules.length
+		})
 		t.ok(allStrings, 'all array objects should be strings')
 		t.end()
 	})


### PR DESCRIPTION
- Uses the built in [`querystring`](https://nodejs.org/api/querystring.html#querystring_querystring_stringify_obj_sep_eq_options) module to build the url.
  - (A string.replace() call should work just as well, but I found this to be more readable.)
- Uses `request` to get the JSON data.
- Uses `JSONStream` to parse the JSON into usable objects. E.g., `[ 'module-name' ]`
- Uses `concat-stream` to concatenate all the incoming objects into an array of strings.

Cleaned up test a little using [every](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every#Examples) instead of filter.

Found solution from [this issue](https://github.com/npm/npm-registry-couchapp/issues/135).
